### PR TITLE
Placecell update

### DIFF
--- a/@vmplacecell/plot.m
+++ b/@vmplacecell/plot.m
@@ -1,6 +1,6 @@
 function [obj, varargout] = plot(obj,varargin)
 %@vmplacecell/plot Plot function for a vmplacecell object.
-%   OBJ = plot(OBJ) creates an imagesc plot for the vmplacecell object. The
+%   OBJ = plot(OBJ,1,'RawMap') creates an imagesc plot for the vmplacecell object. The
 %   map shows the mean firing rates at each grid position.
 %
 %   InspectGUI(OBJ) creates an imagesc plot for a vmplacecell object

--- a/@vmplacecell/plot.m
+++ b/@vmplacecell/plot.m
@@ -15,8 +15,8 @@ function [obj, varargout] = plot(obj,varargin)
 
 Args = struct('LabelsOff',0,'GroupPlots',1,'GroupPlotIndex',1,'Color','b', ...
 		  'ReturnVars',{''}, 'ArgsOnly',0, 'Cmds','', 'Errorbar',0, ...
-          'SIC',0,'Shuffle',0, 'ShuffleSteps',100, 'NumSubPlots',4);
-Args.flags = {'LabelsOff','ArgsOnly','Errorbar','SIC','Shuffle'};
+          'SIC',0,'Shuffle',0, 'ShuffleSteps',100, 'NumSubPlots',4,'RawMap',0,'SmoothedMap',0);
+Args.flags = {'LabelsOff','ArgsOnly','Errorbar','SIC','Shuffle','RawMap','SmoothedMap'};
 [Args,varargin2] = getOptArgs(varargin,Args);
 
 % if user select 'ArgsOnly', return only Args structure for an empty object
@@ -74,7 +74,14 @@ if(~isempty(Args.NumericArguments))
         ylabel('95th percentile SIC')
     else  % if(Args.Errorbar)
         gSteps = obj.data.gridSteps;
-        imagesc(reshape(obj.data.meanFRs(:,n),gSteps,gSteps));
+        if Args.RawMap
+            y = obj.data.maps_raw(:,n);
+        elseif Args.SmoothedMap
+            y = obj.data.maps_adsmooth(:,n);
+        else
+            error('No map specified.');
+         end
+        imagesc(reshape(y,gSteps,gSteps));
         colorbar
     end  % if(Args.Errorbar)
 

--- a/@vmplacecell/vmplacecell.m
+++ b/@vmplacecell/vmplacecell.m
@@ -82,7 +82,15 @@ if(~isempty(dir(Args.RequiredFile)))
 	% load rplparallel object
 	rp = rplparallel('auto',varargin{:});
 	% load spike train file
-	spiketrain = load(Args.RequiredFile);
+    % this is a bit hackish; check whether we have a .mat or a .csv file
+    [d,fn,ext] = fileparts(Args.RequiredFile);
+    if strcmp(ext,'.mat')
+	    spiketrain = load(Args.RequiredFile);
+    elseif strcmp(ext,'.csv')
+        spiketrain.timestamps = load(Args.RequiredFile)';
+    else
+        error(['Unkown file type ' + Args.RequiredFile]);
+    end
 	% save(Args.HPCInputFilename,'Args','um','rp','varargin');
 
 	if(Args.HPC)


### PR DESCRIPTION
A couple of quick fixes to be able to create and plot vmplacecell objects with the modified mountain sort pipeline.

I'm not sure how the vmplacecell/plot function was used before. The docstring says that simply doing

```matlab
vm = vmplacecell('auto');
plot(vm)
```
should bring up a plot of the mean firing rate per place bin, but when I ran those commands, nothing came up. In fact, the vmplacecell object does not even have a `meanFR` member. I had to access the the `maps_raw` or `maps_adsmooth` members to get access to a representation of the place field. 